### PR TITLE
Field attributes

### DIFF
--- a/redpipe/structs.py
+++ b/redpipe/structs.py
@@ -598,6 +598,29 @@ class Struct(object):
 
         return self._data[item]
 
+    def __getattr__(self, item):
+        try:
+            return self._data[item]
+        except KeyError as e:
+            raise AttributeError('Attribute %s not found' % e)
+
+    def __setattr__(self, key, value):
+        try:
+            return super(Struct, self).__setattr__(key, value)
+        except AttributeError as e:
+            if key in self.fields:
+                tpl = 'cannot delete %s from %s indirectly. Use the delete method.'
+                raise InvalidOperation(tpl % (key, self))
+            raise e
+
+    def other__setattr__(self, key, value):
+        try:
+            return super(Struct, self).__setattr__(key, value)
+        except AttributeError as e:
+            if key in self.fields:
+                self._data[key] = value
+            raise e
+
     def __delitem__(self, key):
         """
         Explicitly prevent deleting data from the object via the `del`

--- a/redpipe/structs.py
+++ b/redpipe/structs.py
@@ -609,16 +609,8 @@ class Struct(object):
             return super(Struct, self).__setattr__(key, value)
         except AttributeError as e:
             if key in self.fields:
-                tpl = 'cannot delete %s from %s indirectly. Use the delete method.'
+                tpl = 'cannot set %s from %s indirectly. Use the set method.'
                 raise InvalidOperation(tpl % (key, self))
-            raise e
-
-    def other__setattr__(self, key, value):
-        try:
-            return super(Struct, self).__setattr__(key, value)
-        except AttributeError as e:
-            if key in self.fields:
-                self._data[key] = value
             raise e
 
     def __delitem__(self, key):


### PR DESCRIPTION
This code is un-tested, but should give you an idea of how this could be done. 

`__getattr__`: This function is only called after `__getattribute__` has failed to find the attribute, therefore our version of this fn can simply check `self._data` for the existence of the item and raise an error if that item DNE. As an additional pre-caution we could check that `item` is in `fields`, but I don't think that is necessary, because if it were an item with the same name as an object attribute it would have been returned by `__getattribute__`, so we can be a little more lenient in the get than we are in the set

`__setattr__`: This is not exactly compatible with hbom, but in briefly looking at some code, we don't tend to set model attributes directly all that frequently, so this implementation gives somewhat expected behavior by raising an `InvalidOperation` error, and forces the user to make proper use of the `update` fn. It's sorta a compromise? No magic attribute clashes?